### PR TITLE
Remove numbering

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,93 +33,93 @@ In contrast, the languages provided here are for programming the game logic. The
 ## 🏆🥇 Production Ready
    These languages are documented and stable.  
    *In alphabetical order*. 
-
-1. ### [C++ / Godot module](https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/custom_modules_in_cpp.html)  💍 ⚙️
+   
+### [C++ / Godot module](https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/custom_modules_in_cpp.html)  💍 ⚙️
    
    You can code your entire project (or parts of it) in C++ and include the game logic as Godot modules.
 
-1. ### [C++ / Jenova](https://jenova-framework.github.io/)  🧬 🔌 👥 🔧
+ ### [C++ / Jenova](https://jenova-framework.github.io/)  🧬 🔌 👥 🔧
    Jenova provides not only hot reloadable C++ game scripting, editor support within Visual Studio, Visual Studio Code, and Godot itself, but also a lot of other features like support for nested GDExtension development, an inbuilt virtual machine for starting an entire OS, that can be embedded into the game, and interact with it.
 
-    It also provides its own API for the development of extensions, although currently undocumented.
+   It also provides its own API for the development of extensions, although currently undocumented.
 
    Limited to Windows and Linux as development platform.
 
    A non-free edition that provides encrypted code obfuscation and more, is also available.
 
-1. ### [C++ and Rust](https://github.com/libriscv/godot-sandbox) 🧬 🏰 
+### [C++ and Rust](https://github.com/libriscv/godot-sandbox) 🧬 🏰 
    This mainly focuses on Cpp and Rust support and also features Zig. It sandboxes the code and is suitable for modding support. 
 
-1. ### [C#](https://docs.godotengine.org/en/stable/getting_started/scripting/c_sharp/index.html) 💍 🔌 ⚙️
+### [C#](https://docs.godotengine.org/en/stable/getting_started/scripting/c_sharp/index.html) 💍 🔌 ⚙️
    C# support is made possible by an official Godot module. If you have the dotnet version of Godot or Blazium, it comes built-in. It does not support web export (HTML/wasm) as of now.
-
-1. ### [D](https://github.com/godot-dlang/godot-dlang) 👥 🔌 🔧
+   
+### [D](https://github.com/godot-dlang/godot-dlang) 👥 🔌 🔧
    New, maintained binding to GDExtension. 
 
-1. ### [GDScript](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/index.html) 💍 🧬 🔌 ⚙️
+### [GDScript](https://docs.godotengine.org/en/stable/getting_started/scripting/gdscript/index.html) 💍 🧬 🔌 ⚙️
    GDScript is actively maintained, documented and is stable. It is the primary language in the Godot ecosystem, has the most tutorials online, and deep Godot editor support.
    Can be extended with [Golden Nugget](https://monnef.gitlab.io/golden-gadget/features). 
 
-1. ### [Haxe](https://github.com/SomeRanDev/reflaxe.GDScript) 👥 🔌 🏄
+### [Haxe](https://github.com/SomeRanDev/reflaxe.GDScript) 👥 🔌 🏄
    Does compile Haxe to GDScript.
    Made with the `reflaxe` framework.
 
-1. ### [JavaScript and Typescript](https://github.com/godotjs/GodotJS) 👥 🔌 
+### [JavaScript and Typescript](https://github.com/godotjs/GodotJS) 👥 🔌 
    Currently limited to Godit 4.1 and a rewrite from module to GDExtension is planned, further delaying the development towards modern versions if Godot.
 
-1. ### [Kotlin, Java, and Scala.](https://github.com/utopia-rise/godot-jvm) 👥 🔌 ⚙️
+### [Kotlin, Java, and Scala.](https://github.com/utopia-rise/godot-jvm) 👥 🔌 ⚙️
    Provides proper support for Kotlin and Java. Aims to support Scala in the near future as well. Their [Discord](https://discord.gg/3NSA7fKBMD) is nice and friendly.
 
-1. ### [Nim](https://github.com/godot-nim/gdext-nim) 👥 🔌 🔧
+### [Nim](https://github.com/godot-nim/gdext-nim) 👥 🔌 🔧
    Feature complete, hot reloadable implementation of Nim.
 
-1. ### [Orchestrator](https://github.com/CraterCrash/godot-orchestrator)  👥 🧬 🔧
+### [Orchestrator](https://github.com/CraterCrash/godot-orchestrator)  👥 🧬 🔧
    Orchestrator is a visual scripting language with advanced macro support to provide high-level abstractions.
 Friendly and competent support.
 Also usable for dialog scripting. 
 It provides rich API support, is implemented in C++, and compiles to native code. 
 
-1. ### [Rust](https://github.com/godot-rust/gdext) 👥 🔌 🔧
+### [Rust](https://github.com/godot-rust/gdext) 👥 🔌 🔧
    You can find the project homepage [here.](https://godot-rust.github.io/)
 
-1. ### [Swift](https://github.com/migueldeicaza/SwiftGodot)  👥 🔌 🔧
+### [Swift](https://github.com/migueldeicaza/SwiftGodot)  👥 🔌 🔧
    Very well-supported implementation by Miguel Deicaza.
 
 ## 🤪 Curiosities 
    Stable programming languages, ... with a twist 😉 
 
-1. ### [Enu](https://github.com/dsrw/enu) 👥 🧬 ⚙️
+### [Enu](https://github.com/dsrw/enu) 👥 🧬 ⚙️
    Experimental block-based language and framework. 
 
-1. ### [Ink](https://github.com/inkle/ink) 👥 🔌 🏄
+### [Ink](https://github.com/inkle/ink) 👥 🔌 🏄
    Scripting language for writing interactive narrative.
 
 ## 🥈 Half way there
    In active development, and comparable to being in the beta stage.
 
-1. ### [Go 1](https://github.com/godot-go/godot-go/) 👥 🔌 🔧
+### [Go 1](https://github.com/godot-go/godot-go/) 👥 🔌 🔧
    Go bindings to GDExtension.
 
-1. ### [Go 2](https://github.com/grow-graphics/gd) 👥 🔌 🔧
+### [Go 2](https://github.com/grow-graphics/gd) 👥 🔌 🔧
    Go bindings to GDExtension.
    Possible to use it for shaders.
 
-1. ### [Lua](https://github.com/perbone/luascript) 👥 🧬 🔌 ⚙️
+### [Lua](https://github.com/perbone/luascript) 👥 🧬 🔌 ⚙️
    This version of Lua is currently undergoing a partial rewrite and seems to be stuck in development.
 
-1. ### [Python](https://github.com/touilleMan/godot-python/tree/godot4-meson) 👥 🧬 🔌
-    Currently in reconstruction.
+### [Python](https://github.com/touilleMan/godot-python/tree/godot4-meson) 👥 🧬 🔌
+   Currently in reconstruction.
 
-1. ### [Python 2](https://github.com/niklas2902/py4godot) 👥 🧬 🔌
+### [Python 2](https://github.com/niklas2902/py4godot) 👥 🧬 🔌
    Python implementation from scratch. 
 
-1. ### [WASM](https://github.com/Dheatly23/godot-wasm) 👥 🏰
+### [WASM](https://github.com/Dheatly23/godot-wasm) 👥 🏰
    Bindings for wasm. Implemented via the Rust bindings.
 
-1. ### [WASM 2](https://github.com/ashtonmeuser/godot-wasm) 👥 🏰 ⚙️ 🔧
+### [WASM 2](https://github.com/ashtonmeuser/godot-wasm) 👥 🏰 ⚙️ 🔧
    Allows to load WASM libraries from other languages. Available as both module and GDExtension.
 
-1. ### [Zig](https://github.com/thimenesup/GodotZigBindings) 👥 🔌 🔧
+### [Zig](https://github.com/thimenesup/GodotZigBindings) 👥 🔌 🔧
    Almost no documentation is provided, uncertain about the status of the project. 
 
 ## 🌐 Other Useful links


### PR DESCRIPTION
This fixes a bug, where the link anchor of each item overlaps with the (anyway unnecessary) numbering of the items.