### PR TITLE
Fix typo in extension name from 'Golden Nugget' to 'Golden Gadget'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
    GDScript is actively maintained, documented, and stable.  
 It is the primary language in the Godot ecosystem, has the most tutorials online, and deep Godot editor support.
    
-   Can be extended with [Golden Nugget](https://monnef.gitlab.io/golden-gadget/features). 
+   Can be extended with [Golden Gadget](https://monnef.gitlab.io/golden-gadget/features). 
 
 ### [Go](https://github.com/grow-graphics/gd)  👥 🧩 ⚡ 🌍
    


### PR DESCRIPTION
Hello!

Just noticed a typo in the paragraph regarding GDScript: the library is called "Golden Gadget" and not "Golden Nugget".

Thanks!