### PR TITLE
Godot scala native

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,10 @@ The _TinyCC_ C compiler integrated as a GDExtension.
 ### [Scala Native](https://github.com/julian-avar/gdext-sc-native) 👥 🧩
    In Development, uses Scala Native instead of JVM
 
-### [Scala Native SBT](https://github.com/optical002/godot-scala-native) 👥 🧩
-   In Development, uses Scala Native SBT instead of JVM and instead of Mill like above.
-   Has built-in godot plugin for launching SBT server from editor.
+### [Scala Native SBT](https://github.com/optical002/godot-scala-native) 💍 🧩 🔌
+   Scala Native typesafe, batteries included implementation with SBT build system. Has built-in 
+   godot plugin for launching SBT server from editor. Supports simple syntax, can build nodes 
+   without any annotations (supports nodes for custom inspector display e.g. show range, file open).
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ The _TinyCC_ C compiler integrated as a GDExtension.
    In Development, uses Scala Native instead of JVM
 
 ### [Scala Native SBT](https://github.com/optical002/godot-scala-native) 💍 🧩 🔌
-   Scala Native typesafe, batteries included implementation with SBT build system. Has built-in 
+   Scala Native typesafe, batteries included implementation with SBT build tool. Has built-in 
    godot plugin for launching SBT server from editor. Supports simple syntax, can build nodes 
-   without any annotations (supports nodes for custom inspector display e.g. show range, file open).
+   without any annotations (supports annotations for custom inspector display e.g. show range, file open).
+   Focusing on implementing seamless experience for developing games with godot in scala.
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ The _TinyCC_ C compiler integrated as a GDExtension.
 ### [Scala Native](https://github.com/julian-avar/gdext-sc-native) 👥 🧩
    In Development, uses Scala Native instead of JVM
 
+### [Scala Native SBT](https://github.com/optical002/godot-scala-native) 👥 🧩
+   In Development, uses Scala Native SBT instead of JVM and instead of Mill like above.
+   Has built-in godot plugin for launching SBT server from editor.
+
 ## Help
 
 As a small **volunteer** team with only two active maintainers (@ShalokShalom and @Vivraan), tracking community favourites versus cool upcoming demos of the GDExtension technology is challenging, given our busy schedules and attention spans 🫠

--- a/README.md
+++ b/README.md
@@ -193,13 +193,10 @@ The _TinyCC_ C compiler integrated as a GDExtension.
    In Development, uses Kotlin Native instead of JVM
 
 ### [Scala Native](https://github.com/julian-avar/gdext-sc-native) 👥 🧩
-   In Development, uses Scala Native instead of JVM
+   In Development, uses Scala Native instead of JVM.
 
-### [Scala Native SBT](https://github.com/optical002/godot-scala-native) 💍 🧩 🔌
-   Scala Native typesafe, batteries included implementation with SBT build tool. Has built-in 
-   godot plugin for launching SBT server from editor. Supports simple syntax, can build nodes 
-   without any annotations (supports annotations for custom inspector display e.g. show range, file open).
-   Focusing on implementing seamless experience for developing games with godot in scala.
+### [Scala Native (SBT)](https://github.com/optical002/godot-scala-native) 💍 🧩 🔌
+   Scala Native typesafe, batteries included implementation with the SBT build tool. Has a built-in Godot plugin for launching an SBT server from the editor. Supports simple syntax, can build nodes without any annotations (also supports annotations for custom inspector display e.g. show range, file open). Focused on implementing a seamless experience for developing games with Godot using Scala Native.
 
 ## Help
 


### PR DESCRIPTION
Another implementation of Godot scala-native, which instead utilizes SBT instead of already existing Mill scala-native implementation.